### PR TITLE
Fix stack overflow by expanding shell stack size

### DIFF
--- a/run_simulation.sh
+++ b/run_simulation.sh
@@ -6,9 +6,12 @@ CORES=${2:-2}
 USE_SL=${3:-"TRUE"}
 DO_MPI=${4:-"FALSE"}
 
+# Increase stack size to prevent C stack overflow
+ulimit -s unlimited
+
 # Activate the Python environment
 source ./myenv/bin/activate
 
 # Run the simulation
 echo "Running simulation with: estimator=$ESTIMATOR, cores=$CORES, use_SL=$USE_SL, do_MPI=$DO_MPI"
-Rscript simulation.R $ESTIMATOR $CORES $USE_SL $DO_MPI
+Rscript simulation.R "$ESTIMATOR" "$CORES" "$USE_SL" "$DO_MPI"

--- a/simulation.R
+++ b/simulation.R
@@ -52,6 +52,7 @@ library(purrr)
 library(origami)
 library(sl3)
 options(sl3.verbose = FALSE)
+options(expressions = 500000)
 library(methods) # For R6 class operations
 library(nnet)
 library(ranger)


### PR DESCRIPTION
## Summary
- increase the shell stack size before running simulations

## Testing
- `Rscript package_list.R` *(fails: `Rscript: command not found`)*
- `./run_simulation.sh 'tmle' 1 'TRUE' 'FALSE'` *(fails: `Rscript: command not found`)*