### PR TITLE
Fix vectorized sampling for baseline action

### DIFF
--- a/simulation.R.original
+++ b/simulation.R.original
@@ -109,7 +109,7 @@ simLong <- function(r, J=6, n=10000, t.end=36, gbound=c(0.05,1), ybound=c(0.0001
   source('./src/simcausal_dgp.R', local =TRUE)
   
   # specify intervention rules (t=0 is same as observed)
-  Dset <- set.DAG(D, vecfun=c("StochasticFun")) # locks DAG, consistency checks
+  Dset <- set.DAG(D, vecfun=c("StochasticFun", "cbind")) # locks DAG, consistency checks
   
   # Call the improved function with LaTeX formatting
   if(r==1){

--- a/src/simcausal_fns.R
+++ b/src/simcausal_fns.R
@@ -27,51 +27,70 @@ rbern <- function(n, prob) {
 }
 
 # definition: multinomial
-Multinom <- function(n,probs){
+Multinom <- function(n, probs) {
   # probs is vector or matrix
   # combination of:
   # rcat.b1 from simcausal
   # rmult from glmnet
-  if (!is.na(n) && n == 0) {
-    probs <- matrix(nrow = n, ncol = length(probs), byrow = TRUE)
+  if (is.null(probs)) {
+    stop("'probs' cannot be NULL")
   }
+
+  if (!is.na(n) && n == 0) {
+    return(factor(integer(0)))
+  }
+
   if (is.vector(probs) && !is.na(n) && n > 0) {
-    probs <- matrix(data = probs, nrow = n, ncol = length(probs), 
+    probs <- matrix(data = probs, nrow = n, ncol = length(probs),
                     byrow = TRUE)
   }
+
+  # Bound probabilities to [0,1]
+  probs[probs < 0] <- 0
+  probs[probs > 1] <- 1
+
+  # Normalise each row to sum to 1
+  row_sums <- rowSums(probs)
+  probs <- probs / ifelse(row_sums == 0, 1, row_sums)
+
   x <- t(apply(probs, 1, function(x) rmultinom(1, 1, x)))
-  x <- x %*% seq(ncol(probs))
+  x <- x %*% seq_len(ncol(probs))
   return(as.factor(drop(x)))
 }
 
 # stochastic treatment rule function
-StochasticFun <- function(condition, d, stay_prob=0.95) {
+StochasticFun <- function(condition, d, stay_prob = 0.95) {
   condition[is.na(condition)] <- 0
   n <- length(condition)
   if (!is.matrix(d)) {
     d <- matrix(d, n, length(d), byrow = TRUE)
   }
   J <- ncol(d)
-  
+
   # Create a matrix with higher stay probability and lower switch probability
   switch_prob <- (1 - stay_prob) / (J - 1)  # Adjusted switch probability
-  
+
   # Create a matrix for the probabilities of staying vs. switching
   probs_matrix <- matrix(switch_prob, n, J, byrow = TRUE)
-  for (j in 1:J) {
+  for (j in seq_len(J)) {
     probs_matrix[, j] <- ifelse(condition == j, stay_prob, switch_prob)
   }
-  
+
   # Apply the stochastic adjustments d
   res <- probs_matrix + d
-  
-  # Ensure that no probabilities exceed 1 after the adjustment
+
+  # Bound probabilities to [0,1]
+  res[res < 0] <- 0
   res[res > 1] <- 1
-  
+
   # Replace any resulting NAs with a very small number
   if (any(is.na(res))) {
     res[is.na(res)] <- .Machine$double.eps
   }
-  
+
+  # Normalise each row to sum to 1
+  row_sums <- rowSums(res)
+  res <- res / ifelse(row_sums == 0, 1, row_sums)
+
   return(res)
 }


### PR DESCRIPTION
## Summary
- include `cbind` as a vectorized function when locking the DAG so that baseline multinomial nodes evaluate correctly

## Testing
- `bash -n run_simulation.sh`
